### PR TITLE
Restore and improve automated Gitpod dev setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 **/i686
 i686-elf-tools.sh
 
-.gitpod.*
-.gitpod.Dockerifle
-.gitpod.yml
 build/*.o
 **/windows
 **/.vscode

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,4 @@
+FROM gitpod/workspace-full-vnc
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y nasm grub-pc xorriso qemu-system-i386

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: make
+    command: qemu-system-i386 build/reduce.bin
+
+ports:
+  - port: 5900
+    onOpen: ignore
+  - port: 6080
+    onOpen: open-preview


### PR DESCRIPTION
Hi @sasdallas!

Following our discussion in https://github.com/gitpod-io/gitpod/issues/8102 I took the liberty to restore your earlier Gitpod setup, and I've also enhanced it a little:

- I made the Dockerfile auto-install your dependencies (`nasm`, `grub-pc`, `xorriso`, `qemu-system-i386` based on errors I got running `make`)
- I made the .gitpod.yml auto-start your app (based on what your README.md suggests) and also automatically open the VNC viewer in the IDE

This is what it looks like:

<img width="1439" alt="Screenshot 2022-02-09 at 16 13 35" src="https://user-images.githubusercontent.com/599268/153230335-a0630987-59a9-4217-8c86-8448ea490371.png">

To test it, you can simply open this Pull Request in Gitpod:
https://gitpod.io/#https://github.com/sasdallas/reduceOS/pull/2